### PR TITLE
feat: auto-generate keymap visuals on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,3 +3,36 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+
+  update-keymap-visuals:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Generate keymap SVGs and update README
+        run: |
+          cd scripts/generate-keymap-svg
+          dotnet run -- \
+            --keymap ../../config/corne.keymap \
+            --output ../../docs/img \
+            --layout corne \
+            --update-readme ../../README.md
+
+      - name: Commit updated visuals
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/img/*.svg README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "docs: update keymap visuals [skip ci]"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,30 +1,40 @@
 # My custom keyboards
 ZMK firmware/config for my wireless Corne keyboards.
 
+<!-- BEGIN KEYMAP - AUTO-GENERATED, DO NOT EDIT -->
+
 ## Keyboard layout/ keymap
 
-### Default layer
-![default layer key layout](docs/img/default_layer.svg)
+### default_layer
+![default_layer](docs/img/default_layer.svg)
 
-### Symbols layer (1)
-![symbols layer key layout](docs/img/symbols_layer.svg)
+### symbols
+![symbols](docs/img/symbols_layer.svg)
 
-### Nav layer (2)
-![Navigation layer key layout](docs/img/nav_layer.svg)
-
-- below F3: CTRL+SHIFT+B - build solution (Visual Studio)
-- below F4: CTRL+. - suggestions (Visual Studio/ VSCode)
+### nav
+![nav](docs/img/nav_layer.svg)
 
 ## Combos
 
-| Combo | Keys | Layer |
-|-------|------|-------|
-| ![cut](docs/img/combo_cut.svg) | Z + X | Default |
-| ![copy](docs/img/combo_copy.svg) | X + C | Default |
-| ![paste](docs/img/combo_paste.svg) | C + V | Default |
-| ![caps_word](docs/img/combo_caps_word.svg) | T + Y | Default |
-| ![escape](docs/img/combo_escape.svg) | J + K | Default |
-| ![reset_bluetooth](docs/img/combo_reset_bluetooth.svg) | E+R+T+Y+U+I | Nav |
+### cut
+![cut](docs/img/combo_cut.svg)
+
+### copy
+![copy](docs/img/combo_copy.svg)
+
+### paste
+![paste](docs/img/combo_paste.svg)
+
+### caps_word
+![caps_word](docs/img/combo_caps_word.svg)
+
+### escape
+![escape](docs/img/combo_escape.svg)
+
+### reset_bluetooth
+![reset_bluetooth](docs/img/combo_reset_bluetooth.svg)
+
+<!-- END KEYMAP -->
 
 ## Generating keymap visuals
 

--- a/scripts/generate-keymap-svg/Program.cs
+++ b/scripts/generate-keymap-svg/Program.cs
@@ -5,6 +5,7 @@ var keymapPath = "config/corne.keymap";
 var outputDir = "docs/img";
 var layout = "corne";
 var prefix = "";
+string? readmePath = null;
 
 for (var i = 0; i < args.Length; i++)
 {
@@ -14,6 +15,7 @@ for (var i = 0; i < args.Length; i++)
         case "--output" when i + 1 < args.Length: outputDir = args[++i]; break;
         case "--layout" when i + 1 < args.Length: layout = args[++i]; break;
         case "--prefix" when i + 1 < args.Length: prefix = args[++i]; break;
+        case "--update-readme" when i + 1 < args.Length: readmePath = args[++i]; break;
     }
 }
 
@@ -24,22 +26,73 @@ Directory.CreateDirectory(outputDir);
 
 var filePrefix = string.IsNullOrEmpty(prefix) ? "" : $"{prefix}_";
 var renderer = new SvgRenderer();
+var layerFiles = new List<(string Name, string File)>();
+var comboFiles = new List<(string Name, string File)>();
 
 foreach (var layer in data.Layers)
 {
     var safeName = Regex.Replace(layer.Name.ToLower(), @"[^a-z0-9]+", "_").Trim('_');
     if (safeName.EndsWith("_layer")) safeName = safeName[..^6];
-    var path = Path.Combine(outputDir, $"{filePrefix}{safeName}_layer.svg");
+    var filename = $"{filePrefix}{safeName}_layer.svg";
+    var path = Path.Combine(outputDir, filename);
     File.WriteAllText(path, renderer.RenderLayer(layer, positions));
+    layerFiles.Add((layer.Name, filename));
     Console.WriteLine($"  Generated {path}");
 }
 
 foreach (var combo in data.Combos)
 {
     var comboName = Regex.Replace(combo.Name.ToLower(), @"[^a-z0-9]+", "_").Trim('_');
-    var path = Path.Combine(outputDir, $"{filePrefix}combo_{comboName}.svg");
+    var filename = $"{filePrefix}combo_{comboName}.svg";
+    var path = Path.Combine(outputDir, filename);
     File.WriteAllText(path, renderer.RenderCombo(combo, positions));
+    comboFiles.Add((combo.Name, filename));
     Console.WriteLine($"  Generated {path}");
+}
+
+if (readmePath != null)
+{
+    var readme = File.ReadAllText(readmePath);
+
+    // Compute image path relative to README location
+    var readmeDir = Path.GetDirectoryName(Path.GetFullPath(readmePath)) ?? ".";
+    var imgDir = Path.GetFullPath(outputDir);
+    var relImgDir = Path.GetRelativePath(readmeDir, imgDir).Replace('\\', '/');
+
+    // Build the keymap section
+    var sb = new StringBuilder();
+    sb.AppendLine("<!-- BEGIN KEYMAP - AUTO-GENERATED, DO NOT EDIT -->");
+    sb.AppendLine();
+    sb.AppendLine("## Keyboard layout/ keymap");
+    sb.AppendLine();
+    foreach (var (name, file) in layerFiles)
+    {
+        sb.AppendLine($"### {name}");
+        sb.AppendLine($"![{name}]({relImgDir}/{file})");
+        sb.AppendLine();
+    }
+    sb.AppendLine("## Combos");
+    sb.AppendLine();
+    foreach (var (name, file) in comboFiles)
+    {
+        sb.AppendLine($"### {name}");
+        sb.AppendLine($"![{name}]({relImgDir}/{file})");
+        sb.AppendLine();
+    }
+    sb.Append("<!-- END KEYMAP -->");
+
+    // Replace between markers, or append if markers don't exist
+    var markerPattern = new Regex(
+        @"<!-- BEGIN KEYMAP.*?-->.*?<!-- END KEYMAP -->",
+        RegexOptions.Singleline);
+
+    if (markerPattern.IsMatch(readme))
+        readme = markerPattern.Replace(readme, sb.ToString());
+    else
+        Console.WriteLine("  Warning: no <!-- BEGIN KEYMAP --> markers found in README, skipping update");
+
+    File.WriteAllText(readmePath, readme);
+    Console.WriteLine($"  Updated {readmePath}");
 }
 
 // ─── Models ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `--update-readme` flag to SVG generator that replaces content between `<!-- BEGIN KEYMAP -->` markers
- Add GitHub Actions workflow to regenerate SVGs and update README on every push to main
- Split combo visuals into individual SVGs for clarity

## Test plan
- [ ] Merge and verify the `update-keymap-visuals` workflow runs
- [ ] Check that README is auto-updated with correct SVG paths