### PR TITLE
fix: remove connector lines from combo visuals

### DIFF
--- a/docs/img/combo_caps_word.svg
+++ b/docs/img/combo_caps_word.svg
@@ -45,6 +45,5 @@
   <rect x="560.0" y="176.8" width="52.0" height="52.0" rx="6" fill="none" stroke="#585b70" stroke-width="0.5" opacity="0.3"/>
   <rect x="280.0" y="14.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
   <rect x="476.0" y="14.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
-  <line x1="306.0" y1="40.0" x2="502.0" y2="40.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
   <text x="404.0" y="45.0" text-anchor="middle" fill="#f38ba8" font-size="11px" font-weight="bold" font-family="Inter, SF Pro Text, Segoe UI, system-ui, sans-serif">CapsWd</text>
 </svg>

--- a/docs/img/combo_copy.svg
+++ b/docs/img/combo_copy.svg
@@ -45,6 +45,5 @@
   <rect x="560.0" y="176.8" width="52.0" height="52.0" rx="6" fill="none" stroke="#585b70" stroke-width="0.5" opacity="0.3"/>
   <rect x="112.0" y="119.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
   <rect x="168.0" y="112.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
-  <line x1="138.0" y1="145.0" x2="194.0" y2="138.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
   <text x="166.0" y="146.5" text-anchor="middle" fill="#f38ba8" font-size="11px" font-weight="bold" font-family="Inter, SF Pro Text, Segoe UI, system-ui, sans-serif">C-C</text>
 </svg>

--- a/docs/img/combo_cut.svg
+++ b/docs/img/combo_cut.svg
@@ -45,6 +45,5 @@
   <rect x="560.0" y="176.8" width="52.0" height="52.0" rx="6" fill="none" stroke="#585b70" stroke-width="0.5" opacity="0.3"/>
   <rect x="56.0" y="133.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
   <rect x="112.0" y="119.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
-  <line x1="82.0" y1="159.0" x2="138.0" y2="145.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
   <text x="110.0" y="157.0" text-anchor="middle" fill="#f38ba8" font-size="11px" font-weight="bold" font-family="Inter, SF Pro Text, Segoe UI, system-ui, sans-serif">C-X</text>
 </svg>

--- a/docs/img/combo_escape.svg
+++ b/docs/img/combo_escape.svg
@@ -45,6 +45,5 @@
   <rect x="560.0" y="176.8" width="52.0" height="52.0" rx="6" fill="none" stroke="#585b70" stroke-width="0.5" opacity="0.3"/>
   <rect x="532.0" y="63.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
   <rect x="588.0" y="56.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
-  <line x1="558.0" y1="89.0" x2="614.0" y2="82.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
   <text x="586.0" y="90.5" text-anchor="middle" fill="#f38ba8" font-size="11px" font-weight="bold" font-family="Inter, SF Pro Text, Segoe UI, system-ui, sans-serif">Esc</text>
 </svg>

--- a/docs/img/combo_paste.svg
+++ b/docs/img/combo_paste.svg
@@ -45,6 +45,5 @@
   <rect x="560.0" y="176.8" width="52.0" height="52.0" rx="6" fill="none" stroke="#585b70" stroke-width="0.5" opacity="0.3"/>
   <rect x="168.0" y="112.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
   <rect x="224.0" y="119.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
-  <line x1="194.0" y1="138.0" x2="250.0" y2="145.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
   <text x="222.0" y="146.5" text-anchor="middle" fill="#f38ba8" font-size="11px" font-weight="bold" font-family="Inter, SF Pro Text, Segoe UI, system-ui, sans-serif">C-V</text>
 </svg>

--- a/docs/img/combo_reset_bluetooth.svg
+++ b/docs/img/combo_reset_bluetooth.svg
@@ -49,10 +49,5 @@
   <rect x="168.0" y="0.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
   <rect x="532.0" y="7.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
   <rect x="588.0" y="0.0" width="52.0" height="52.0" rx="6" fill="#f38ba8" opacity="0.2" stroke="#f38ba8" stroke-width="2"/>
-  <line x1="306.0" y1="40.0" x2="502.0" y2="40.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
-  <line x1="502.0" y1="40.0" x2="250.0" y2="33.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
-  <line x1="250.0" y1="33.0" x2="194.0" y2="26.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
-  <line x1="194.0" y1="26.0" x2="558.0" y2="33.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
-  <line x1="558.0" y1="33.0" x2="614.0" y2="26.0" stroke="#f38ba8" stroke-width="2" opacity="0.6"/>
   <text x="404.0" y="38.0" text-anchor="middle" fill="#f38ba8" font-size="11px" font-weight="bold" font-family="Inter, SF Pro Text, Segoe UI, system-ui, sans-serif">BT Clr</text>
 </svg>

--- a/scripts/generate-keymap-svg/Program.cs
+++ b/scripts/generate-keymap-svg/Program.cs
@@ -397,9 +397,6 @@ class SvgRenderer
             sb.AppendLine($"""  <rect x="{F(kp.X)}" y="{F(kp.Y)}" width="{F(W)}" height="{F(H)}"{transform}rx="{Rx}" fill="{ComboColor}" opacity="0.2" stroke="{ComboColor}" stroke-width="2"/>""");
         }
 
-        for (var j = 0; j < centers.Count - 1; j++)
-            sb.AppendLine($"""  <line x1="{F(centers[j].X)}" y1="{F(centers[j].Y)}" x2="{F(centers[j + 1].X)}" y2="{F(centers[j + 1].Y)}" stroke="{ComboColor}" stroke-width="2" opacity="0.6"/>""");
-
         // Label binding result
         if (centers.Count > 0)
         {


### PR DESCRIPTION
## Summary
- Remove the connector lines between highlighted keys in combo SVGs
- Keep just the key highlights and label text for cleaner visuals